### PR TITLE
Fix :: CommonCode, WashInfo 에서 테이블과 데이터 타입이 맞지 않는 필드 수정

### DIFF
--- a/module-api/src/main/java/com/kernel360/commoncode/dto/CommonCodeDto.java
+++ b/module-api/src/main/java/com/kernel360/commoncode/dto/CommonCodeDto.java
@@ -9,7 +9,7 @@ import java.time.LocalDate;
  */
 public record CommonCodeDto(Long codeNo,
                             String codeName,
-                            Integer upperNo,
+                            Long upperNo,
                             String upperName,
                             Integer sortOrder,
 
@@ -27,7 +27,7 @@ public record CommonCodeDto(Long codeNo,
     public static CommonCodeDto of(
             Long codeNo,
             String codeName,
-            Integer upperNo,
+            Long upperNo,
             String upperName,
             Integer sortOrder,
             Boolean isUsed,

--- a/module-api/src/test/java/com/kernel360/commoncode/controller/CommonCodeControllerRestDocsTest.java
+++ b/module-api/src/test/java/com/kernel360/commoncode/controller/CommonCodeControllerRestDocsTest.java
@@ -29,7 +29,7 @@ class CommonCodeControllerRestDocsTest extends ControllerTest {
                 CommonCodeDto.of(
                         11L,
                         "Sedan",
-                        10,
+                        10L,
                         "cartype",
                         1,
                         true,
@@ -41,7 +41,7 @@ class CommonCodeControllerRestDocsTest extends ControllerTest {
                 CommonCodeDto.of(
                         12L,
                         "Hatchback",
-                        10,
+                        10L,
                         "cartype",
                         2,
                         true,

--- a/module-api/src/test/java/com/kernel360/commoncode/controller/CommonCodeControllerTest.java
+++ b/module-api/src/test/java/com/kernel360/commoncode/controller/CommonCodeControllerTest.java
@@ -21,7 +21,7 @@ class CommonCodeControllerTest extends ControllerTest {
         String pathVariable = "color";
         Long codeNo = 1L;
         String codeName = "테스트용 코드";
-        Integer upperNo = null;
+        Long upperNo = null;
         String upperName = null;
         Integer sortOrder = 1;
         Boolean isUsed = true;

--- a/module-batch/build.gradle
+++ b/module-batch/build.gradle
@@ -21,11 +21,6 @@ repositories {
     mavenCentral()
 }
 
-ext {
-    set('springCloudVersion', "2023.0.0")
-}
-
-
 dependencies {
     implementation project(':module-domain')
 
@@ -33,7 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-batch'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'org.postgresql:postgresql'
-    runtimeOnly 'com.h2database:h2'
+
     // jackson
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.15.3'
 
@@ -49,12 +44,6 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.batch:spring-batch-test'
     testImplementation 'com.navercorp.fixturemonkey:fixture-monkey-starter:1.0.0'
-}
-
-dependencyManagement {
-    imports {
-        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
-    }
 }
 
 tasks.named('test') {

--- a/module-batch/src/main/java/com/kernel360/modulebatch/ModuleBatchApplication.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/ModuleBatchApplication.java
@@ -15,9 +15,8 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableJpaAuditing
 @EnableBatchProcessing
 @SpringBootApplication
-@EnableJpaRepositories({"com.kernel360.ecolife.repository", "com.kernel360.product.repository",
-        "com.kernel360.brand.repository"})
-@EntityScan({"com.kernel360.ecolife.entity", "com.kernel360.product.entity", "com.kernel360.brand.entity"})
+@EnableJpaRepositories({"com.kernel360"})
+@EntityScan({"com.kernel360"})
 public class ModuleBatchApplication {
 
     public static void main(String[] args) {

--- a/module-domain/src/main/java/com/kernel360/commoncode/entity/CommonCode.java
+++ b/module-domain/src/main/java/com/kernel360/commoncode/entity/CommonCode.java
@@ -23,7 +23,7 @@ public class CommonCode extends BaseEntity {
     private String codeName;
 
     @Column(name = "upper_no")
-    private Integer upperNo;
+    private Long upperNo;
 
     @Column(name = "upper_name", length = Integer.MAX_VALUE)
     private String upperName;

--- a/module-domain/src/main/java/com/kernel360/washinfo/entity/WashInfo.java
+++ b/module-domain/src/main/java/com/kernel360/washinfo/entity/WashInfo.java
@@ -24,8 +24,8 @@ public class WashInfo extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "wash_info_id_gen")
     @SequenceGenerator(name = "wash_info_id_gen", sequenceName = "wash_info_wash_no_seq", allocationSize = 50)
-    @Column(nullable = false)
-    private Integer washNo;
+    @Column(name = "wash_no", nullable = false)
+    private Long washNo;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_no", nullable = false)


### PR DESCRIPTION
## 💡 Motivation and Context
`CommonCode, WashInfo 에서 테이블과 데이터 타입이 맞지 않는 필드 수정`

<br>

## 🔨 Modified
> CommonCode, WashInfo 에서 테이블(BIGINT)과 데이터 타입이 맞지 않는 필드 수정하였습니다.
  - _`CommonCode` 의 `upperNo` 를 `Long` 으로 변경_
  - _`WashInfo` 의 `washNo` 를 `Long` 으로 변경_

> `Module-Batch` 의 엔티티 스캔, 레포지토리 스캔 범위를 `com.kernel360` 으로 변경하였습니다.

<br>

## 🌟 More
- _ `JpaAuditor` 를 커스텀해서 `BaseRawEntity` 없이 조건분기에 따라서 자원 작성/변경자를 기록하도록 변경하고 싶음 _

<br>

---


### 📋 커밋 전 체크리스트
- [ ] 추가/변경에 대한 단위 테스트를 완료하였습니다.
- [x] 컨벤션에 맞게 작성하였습니다.

<br>

### 🤟🏻 PR로 완료된 이슈
closes #278
