### PR TITLE
feature 게시판 API 초안 작성

### DIFF
--- a/module-api/src/main/java/com/kernel360/bbs/code/BBSBusinessCode.java
+++ b/module-api/src/main/java/com/kernel360/bbs/code/BBSBusinessCode.java
@@ -8,9 +8,10 @@ import org.springframework.http.HttpStatus;
 public enum BBSBusinessCode implements BusinessCode {
 
     SUCCESS_REQUEST_GET_BBS(HttpStatus.OK.value(), "BBC001", "게시판 목록 조회 성공"),
-    SUCCESS_REQUEST_CREATED_BBS(HttpStatus.CREATED.value(), "BBC002", "게시글 작성 성공"),
-    SUCCESS_REQUEST_MODIFIED_BBS(HttpStatus.OK.value(), "BBC003", "게시글 수정 성공"),
-    SUCCESS_REQUEST_DELETE_BBS(HttpStatus.OK.value(), "BBC004", "게시글 삭제 성공");
+    SUCCESS_REQUEST_GET_BBS_VIEW(HttpStatus.OK.value(), "BBC002", "게시판 상세 조회 성공"),
+    SUCCESS_REQUEST_CREATED_BBS(HttpStatus.CREATED.value(), "BBC003", "게시글 작성 성공"),
+    SUCCESS_REQUEST_MODIFIED_BBS(HttpStatus.OK.value(), "BBC004", "게시글 수정 성공"),
+    SUCCESS_REQUEST_DELETE_BBS(HttpStatus.OK.value(), "BBC005", "게시글 삭제 성공");
 
     private final int status;
     private final String code;
@@ -18,16 +19,14 @@ public enum BBSBusinessCode implements BusinessCode {
 
     @Override
     public int getStatus() {
-        return 0;
+        return status;
     }
 
     @Override
-    public String getCode() {
-        return null;
-    }
+    public String getCode() { return code; }
 
     @Override
     public String getMessage() {
-        return null;
+        return message;
     }
 }

--- a/module-api/src/main/java/com/kernel360/bbs/code/BBSBusinessCode.java
+++ b/module-api/src/main/java/com/kernel360/bbs/code/BBSBusinessCode.java
@@ -1,0 +1,33 @@
+package com.kernel360.bbs.code;
+
+import com.kernel360.code.BusinessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum BBSBusinessCode implements BusinessCode {
+
+    SUCCESS_REQUEST_GET_BBS(HttpStatus.OK.value(), "BBC001", "게시판 목록 조회 성공"),
+    SUCCESS_REQUEST_CREATED_BBS(HttpStatus.CREATED.value(), "BBC002", "게시글 작성 성공"),
+    SUCCESS_REQUEST_MODIFIED_BBS(HttpStatus.OK.value(), "BBC003", "게시글 수정 성공"),
+    SUCCESS_REQUEST_DELETE_BBS(HttpStatus.OK.value(), "BBC004", "게시글 삭제 성공");
+
+    private final int status;
+    private final String code;
+    private final String message;
+
+    @Override
+    public int getStatus() {
+        return 0;
+    }
+
+    @Override
+    public String getCode() {
+        return null;
+    }
+
+    @Override
+    public String getMessage() {
+        return null;
+    }
+}

--- a/module-api/src/main/java/com/kernel360/bbs/code/BBSErrorCode.java
+++ b/module-api/src/main/java/com/kernel360/bbs/code/BBSErrorCode.java
@@ -1,0 +1,31 @@
+package com.kernel360.bbs.code;
+
+import com.kernel360.code.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum BBSErrorCode implements ErrorCode {
+
+    FAILED_GET_BBS_LIST(HttpStatus.NO_CONTENT.value(), "BMC001", "게시판 목록을 찾을 수 없음."),
+    FAILED_GET_BBS_ONE(HttpStatus.NO_CONTENT.value(), "BMC002", "게시글을 찾을 수 없음.");
+
+    private final int status;
+    private final String code;
+    private final String message;
+
+    @Override
+    public int getStatus() {
+        return 0;
+    }
+
+    @Override
+    public String getCode() {
+        return null;
+    }
+
+    @Override
+    public String getMessage() {
+        return null;
+    }
+}

--- a/module-api/src/main/java/com/kernel360/bbs/code/BBSErrorCode.java
+++ b/module-api/src/main/java/com/kernel360/bbs/code/BBSErrorCode.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 public enum BBSErrorCode implements ErrorCode {
 
     FAILED_GET_BBS_LIST(HttpStatus.NO_CONTENT.value(), "BMC001", "게시판 목록을 찾을 수 없음."),
-    FAILED_GET_BBS_ONE(HttpStatus.NO_CONTENT.value(), "BMC002", "게시글을 찾을 수 없음.");
+    FAILED_GET_BBS_VIEW(HttpStatus.NO_CONTENT.value(), "BMC002", "게시글을 찾을 수 없음.");
 
     private final int status;
     private final String code;
@@ -16,16 +16,16 @@ public enum BBSErrorCode implements ErrorCode {
 
     @Override
     public int getStatus() {
-        return 0;
+        return status;
     }
 
     @Override
     public String getCode() {
-        return null;
+        return code;
     }
 
     @Override
     public String getMessage() {
-        return null;
+        return message;
     }
 }

--- a/module-api/src/main/java/com/kernel360/bbs/controller/BBSController.java
+++ b/module-api/src/main/java/com/kernel360/bbs/controller/BBSController.java
@@ -2,6 +2,7 @@ package com.kernel360.bbs.controller;
 
 import com.kernel360.bbs.code.BBSBusinessCode;
 import com.kernel360.bbs.dto.BBSDto;
+import com.kernel360.bbs.dto.BBSListDto;
 import com.kernel360.bbs.service.BBSService;
 import com.kernel360.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -16,27 +17,48 @@ public class BBSController {
     private final BBSService bbsService;
 
     @GetMapping("/bbs")
-    public ResponseEntity<ApiResponse<Page<BBSDto>>> getBBS(
-            @RequestParam(value = "bbsType", defaultValue = "")String bbsType,
+    public ResponseEntity<ApiResponse<Page<BBSListDto>>> getBBS(
+            @RequestParam(value = "type", defaultValue = "") String type,
             @RequestParam(value = "keyword", required = false) String keyword, Pageable pageable
     ){
-        return ApiResponse.toResponseEntity(BBSBusinessCode.SUCCESS_REQUEST_GET_BBS, bbsService.getBBSWithCondition(bbsType, keyword, pageable));
+        Page<BBSListDto> result = bbsService.getBBSWithCondition(type, keyword, pageable);
+
+        return ApiResponse.toResponseEntity(BBSBusinessCode.SUCCESS_REQUEST_GET_BBS, result);
+    }
+
+    @GetMapping("/bbs/{bbsNo}")
+    public ResponseEntity<ApiResponse<BBSDto>> getBBSView(@PathVariable Long bbsNo){
+
+        return ApiResponse.toResponseEntity(BBSBusinessCode.SUCCESS_REQUEST_GET_BBS_VIEW, bbsService.getBBSView(bbsNo));
+    }
+
+    @GetMapping("/bbs/reply")
+    public ResponseEntity<ApiResponse<Page<BBSDto>>> getBBSReply(@RequestParam Long upperNo, Pageable pageable){
+
+        return ApiResponse.toResponseEntity(BBSBusinessCode.SUCCESS_REQUEST_GET_BBS_VIEW, bbsService.getBBSReply(upperNo, pageable));
     }
 
     @PostMapping("/bbs")
-    public ResponseEntity<ApiResponse<BBSDto>> saveBBS(@RequestBody BBSDto bbsDto){
+    public ResponseEntity<ApiResponse<BBSDto>> saveBBS(@RequestBody BBSDto bbsDto, @RequestHeader("Id") String id){
 
-        return ApiResponse.toResponseEntity(BBSBusinessCode.SUCCESS_REQUEST_GET_BBS);
+        bbsService.saveBBS(bbsDto, id);
+
+        return ApiResponse.toResponseEntity(BBSBusinessCode.SUCCESS_REQUEST_CREATED_BBS);
     }
 
     @PatchMapping("/bbs")
-    public ResponseEntity<ApiResponse<BBSDto>> modifyBBS(@RequestBody BBSDto bbsDto){
+    public ResponseEntity<ApiResponse<BBSDto>> modifyBBS(@RequestBody BBSDto bbsDto, @RequestHeader("Id") String id){
 
-        return ApiResponse.toResponseEntity(BBSBusinessCode.SUCCESS_REQUEST_GET_BBS);
+        bbsService.saveBBS(bbsDto, id);
+
+        return ApiResponse.toResponseEntity(BBSBusinessCode.SUCCESS_REQUEST_MODIFIED_BBS);
     }
 
     @DeleteMapping("/bbs")
-    public ResponseEntity<ApiResponse<BBSDto>> deleteBBS(@RequestBody BBSDto bbsDto){
-        return ApiResponse.toResponseEntity(BBSBusinessCode.SUCCESS_REQUEST_GET_BBS);
+    public ResponseEntity<ApiResponse<BBSDto>> deleteBBS(@RequestParam Long bbsNo){
+
+        bbsService.deleteBBS(bbsNo);
+
+        return ApiResponse.toResponseEntity(BBSBusinessCode.SUCCESS_REQUEST_DELETE_BBS);
     }
 }

--- a/module-api/src/main/java/com/kernel360/bbs/controller/BBSController.java
+++ b/module-api/src/main/java/com/kernel360/bbs/controller/BBSController.java
@@ -10,33 +10,32 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@RestController("/bbs")
+@RestController
 @RequiredArgsConstructor
 public class BBSController {
     private final BBSService bbsService;
 
-    @GetMapping("")
+    @GetMapping("/bbs")
     public ResponseEntity<ApiResponse<Page<BBSDto>>> getBBS(
-            @RequestParam(value = "sortType", defaultValue = "latest")String sortType,
+            @RequestParam(value = "bbsType", defaultValue = "")String bbsType,
             @RequestParam(value = "keyword", required = false) String keyword, Pageable pageable
     ){
-
-        return ApiResponse.toResponseEntity(BBSBusinessCode.SUCCESS_REQUEST_GET_BBS, bbsService.getBBSWithCondition(sortType, keyword, pageable));
+        return ApiResponse.toResponseEntity(BBSBusinessCode.SUCCESS_REQUEST_GET_BBS, bbsService.getBBSWithCondition(bbsType, keyword, pageable));
     }
 
-    @PostMapping("/save")
+    @PostMapping("/bbs")
     public ResponseEntity<ApiResponse<BBSDto>> saveBBS(@RequestBody BBSDto bbsDto){
 
         return ApiResponse.toResponseEntity(BBSBusinessCode.SUCCESS_REQUEST_GET_BBS);
     }
 
-    @PatchMapping("/modifiy")
+    @PatchMapping("/bbs")
     public ResponseEntity<ApiResponse<BBSDto>> modifyBBS(@RequestBody BBSDto bbsDto){
 
         return ApiResponse.toResponseEntity(BBSBusinessCode.SUCCESS_REQUEST_GET_BBS);
     }
 
-    @DeleteMapping("/delete")
+    @DeleteMapping("/bbs")
     public ResponseEntity<ApiResponse<BBSDto>> deleteBBS(@RequestBody BBSDto bbsDto){
         return ApiResponse.toResponseEntity(BBSBusinessCode.SUCCESS_REQUEST_GET_BBS);
     }

--- a/module-api/src/main/java/com/kernel360/bbs/controller/BBSController.java
+++ b/module-api/src/main/java/com/kernel360/bbs/controller/BBSController.java
@@ -1,0 +1,43 @@
+package com.kernel360.bbs.controller;
+
+import com.kernel360.bbs.code.BBSBusinessCode;
+import com.kernel360.bbs.dto.BBSDto;
+import com.kernel360.bbs.service.BBSService;
+import com.kernel360.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController("/bbs")
+@RequiredArgsConstructor
+public class BBSController {
+    private final BBSService bbsService;
+
+    @GetMapping("")
+    public ResponseEntity<ApiResponse<Page<BBSDto>>> getBBS(
+            @RequestParam(value = "sortType", defaultValue = "latest")String sortType,
+            @RequestParam(value = "keyword", required = false) String keyword, Pageable pageable
+    ){
+
+        return ApiResponse.toResponseEntity(BBSBusinessCode.SUCCESS_REQUEST_GET_BBS, bbsService.getBBSWithCondition(sortType, keyword, pageable));
+    }
+
+    @PostMapping("/save")
+    public ResponseEntity<ApiResponse<BBSDto>> saveBBS(@RequestBody BBSDto bbsDto){
+
+        return ApiResponse.toResponseEntity(BBSBusinessCode.SUCCESS_REQUEST_GET_BBS);
+    }
+
+    @PatchMapping("/modifiy")
+    public ResponseEntity<ApiResponse<BBSDto>> modifyBBS(@RequestBody BBSDto bbsDto){
+
+        return ApiResponse.toResponseEntity(BBSBusinessCode.SUCCESS_REQUEST_GET_BBS);
+    }
+
+    @DeleteMapping("/delete")
+    public ResponseEntity<ApiResponse<BBSDto>> deleteBBS(@RequestBody BBSDto bbsDto){
+        return ApiResponse.toResponseEntity(BBSBusinessCode.SUCCESS_REQUEST_GET_BBS);
+    }
+}

--- a/module-api/src/main/java/com/kernel360/bbs/dto/BBSDto.java
+++ b/module-api/src/main/java/com/kernel360/bbs/dto/BBSDto.java
@@ -3,7 +3,7 @@ package com.kernel360.bbs.dto;
 import com.kernel360.bbs.entity.BBS;
 import com.kernel360.member.dto.MemberDto;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 /**
  * DTO for {@link com.kernel360.bbs.entity.BBS}
@@ -15,9 +15,9 @@ public record BBSDto(
         String title,
         String contents,
         Boolean isVisible,
-        LocalDate createdAt,
+        LocalDateTime createdAt,
         String createdBy,
-        LocalDate modifiedAt,
+        LocalDateTime modifiedAt,
         String modifiedBy,
         Long viewCount,
         MemberDto memberDto
@@ -30,9 +30,9 @@ public record BBSDto(
             String title,
             String contents,
             Boolean isVisible,
-            LocalDate createdAt,
+            LocalDateTime createdAt,
             String createdBy,
-            LocalDate modifiedAt,
+            LocalDateTime modifiedAt,
             String modifiedBy,
             Long viewCount,
             MemberDto memberDto

--- a/module-api/src/main/java/com/kernel360/bbs/dto/BBSDto.java
+++ b/module-api/src/main/java/com/kernel360/bbs/dto/BBSDto.java
@@ -1,0 +1,73 @@
+package com.kernel360.bbs.dto;
+
+import com.kernel360.bbs.entity.BBS;
+import com.kernel360.member.entity.Member;
+import org.springframework.cglib.core.Local;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+
+/**
+ * DTO for {@link com.kernel360.bbs.entity.BBS}
+ */
+public record BBSDto(
+        Long bbsNo,
+        Long upperNo,
+        String type,
+        String title,
+        String contents,
+        Boolean isVisible,
+        LocalDate createdAt,
+        String createdBy,
+        LocalDate modifiedAt,
+        String modifiedBy,
+        Long viewCount,
+        Member member
+    ) {
+    public static BBSDto of(
+            Long bbsNo,
+            Long upperNo,
+            String type,
+            String title,
+            String contents,
+            Boolean isVisible,
+            LocalDate createdAt,
+            String createdBy,
+            LocalDate modifiedAt,
+            String modifiedBy,
+            Long viewConut,
+            Member member
+    ){
+        return new BBSDto(
+            bbsNo,
+            upperNo,
+            type,
+            title,
+            contents,
+            isVisible,
+            createdAt,
+            createdBy,
+            modifiedAt,
+            modifiedBy,
+            viewConut,
+            member
+        );
+    }
+
+    public static BBSDto from(BBS entity){
+        return new BBSDto(
+                entity.getBbsNo(),
+                entity.getUpperNo(),
+                entity.getType(),
+                entity.getTitle(),
+                entity.getContents(),
+                entity.getIsVisible(),
+                entity.getCreatedAt(),
+                entity.getCreatedBy(),
+                entity.getModifiedAt(),
+                entity.getModifiedBy(),
+                entity.getViewConut(),
+                entity.getMember()
+        );
+    }
+}

--- a/module-api/src/main/java/com/kernel360/bbs/dto/BBSDto.java
+++ b/module-api/src/main/java/com/kernel360/bbs/dto/BBSDto.java
@@ -2,10 +2,7 @@ package com.kernel360.bbs.dto;
 
 import com.kernel360.bbs.entity.BBS;
 import com.kernel360.member.dto.MemberDto;
-import com.kernel360.member.entity.Member;
-import org.springframework.cglib.core.Local;
 
-import java.io.Serializable;
 import java.time.LocalDate;
 
 /**
@@ -72,5 +69,18 @@ public record BBSDto(
                 MemberDto.from(entity.getMember())
         );
     }
+
+
+//    public BBS toEntity() {
+//        return BBS.create(
+//                this.bbsNo(),
+//                this.upperNo(),
+//                this.title(),
+//                this.contents()
+//
+//        );
+//    }
+
+
 
 }

--- a/module-api/src/main/java/com/kernel360/bbs/dto/BBSDto.java
+++ b/module-api/src/main/java/com/kernel360/bbs/dto/BBSDto.java
@@ -1,6 +1,7 @@
 package com.kernel360.bbs.dto;
 
 import com.kernel360.bbs.entity.BBS;
+import com.kernel360.member.dto.MemberDto;
 import com.kernel360.member.entity.Member;
 import org.springframework.cglib.core.Local;
 
@@ -22,8 +23,9 @@ public record BBSDto(
         LocalDate modifiedAt,
         String modifiedBy,
         Long viewCount,
-        Member member
+        MemberDto memberDto
     ) {
+
     public static BBSDto of(
             Long bbsNo,
             Long upperNo,
@@ -35,8 +37,8 @@ public record BBSDto(
             String createdBy,
             LocalDate modifiedAt,
             String modifiedBy,
-            Long viewConut,
-            Member member
+            Long viewCount,
+            MemberDto memberDto
     ){
         return new BBSDto(
             bbsNo,
@@ -49,8 +51,8 @@ public record BBSDto(
             createdBy,
             modifiedAt,
             modifiedBy,
-            viewConut,
-            member
+            viewCount,
+            memberDto
         );
     }
 
@@ -66,8 +68,9 @@ public record BBSDto(
                 entity.getCreatedBy(),
                 entity.getModifiedAt(),
                 entity.getModifiedBy(),
-                entity.getViewConut(),
-                entity.getMember()
+                entity.getViewCount(),
+                MemberDto.from(entity.getMember())
         );
     }
+
 }

--- a/module-api/src/main/java/com/kernel360/bbs/dto/BBSListDto.java
+++ b/module-api/src/main/java/com/kernel360/bbs/dto/BBSListDto.java
@@ -1,0 +1,19 @@
+package com.kernel360.bbs.dto;
+
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@RequiredArgsConstructor
+public class BBSListDto {
+    Long bbsNo;
+    String type;
+    String title;
+    LocalDate createdAt;
+    String createdBy;
+    Long viewCount;
+    Long memberNo;
+    String id;
+}

--- a/module-api/src/main/java/com/kernel360/bbs/dto/BBSListDto.java
+++ b/module-api/src/main/java/com/kernel360/bbs/dto/BBSListDto.java
@@ -3,7 +3,7 @@ package com.kernel360.bbs.dto;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Data
 @RequiredArgsConstructor
@@ -11,7 +11,7 @@ public class BBSListDto {
     Long bbsNo;
     String type;
     String title;
-    LocalDate createdAt;
+    LocalDateTime createdAt;
     String createdBy;
     Long viewCount;
     Long memberNo;

--- a/module-api/src/main/java/com/kernel360/bbs/enumset/BBSType.java
+++ b/module-api/src/main/java/com/kernel360/bbs/enumset/BBSType.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum BBSType {
-    QNA, FREE, BOAST, RECOMMAND, NOTICE;
+    QNA, FREE, BOAST, RECOMMAND, NOTICE, REPLY;
 
     String type;
 }

--- a/module-api/src/main/java/com/kernel360/bbs/enumset/BBSType.java
+++ b/module-api/src/main/java/com/kernel360/bbs/enumset/BBSType.java
@@ -1,0 +1,10 @@
+package com.kernel360.bbs.enumset;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum BBSType {
+    QNA, FREE, BOAST, RECOMMAND, NOTICE;
+
+    String type;
+}

--- a/module-api/src/main/java/com/kernel360/bbs/repository/BBSRepository.java
+++ b/module-api/src/main/java/com/kernel360/bbs/repository/BBSRepository.java
@@ -1,9 +1,16 @@
 package com.kernel360.bbs.repository;
 
+import com.kernel360.bbs.dto.BBSListDto;
 import com.kernel360.bbs.entity.BBS;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface BBSRepository extends BBSRepositoryJPA, BBSRepositoryDSL {
-    Page<BBS> getBBSWithCondition(String bbsType, String keyword, Pageable pageable);
+    Page<BBSListDto> getBBSWithCondition(String type, String keyword, Pageable pageable);
+
+    BBS findOneByBbsNo(Long bbsNo);
+
+    Page<BBS> findAllByUpperNo(Long upperNo, Pageable pageable);
+
+    void deleteByBbsNo(Long bbsNo);
 }

--- a/module-api/src/main/java/com/kernel360/bbs/repository/BBSRepository.java
+++ b/module-api/src/main/java/com/kernel360/bbs/repository/BBSRepository.java
@@ -1,11 +1,9 @@
 package com.kernel360.bbs.repository;
 
-import com.kernel360.bbs.dto.BBSDto;
+import com.kernel360.bbs.entity.BBS;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Repository;
 
-@Repository
-public interface BBSRepository {
-    Page<BBSDto> getBBSWithCondition(String sortType, String keyword, Pageable pageable);
+public interface BBSRepository extends BBSRepositoryJPA, BBSRepositoryDSL {
+    Page<BBS> getBBSWithCondition(String bbsType, String keyword, Pageable pageable);
 }

--- a/module-api/src/main/java/com/kernel360/bbs/repository/BBSRepository.java
+++ b/module-api/src/main/java/com/kernel360/bbs/repository/BBSRepository.java
@@ -1,0 +1,11 @@
+package com.kernel360.bbs.repository;
+
+import com.kernel360.bbs.dto.BBSDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BBSRepository {
+    Page<BBSDto> getBBSWithCondition(String sortType, String keyword, Pageable pageable);
+}

--- a/module-api/src/main/java/com/kernel360/bbs/repository/BBSRepositoryDSL.java
+++ b/module-api/src/main/java/com/kernel360/bbs/repository/BBSRepositoryDSL.java
@@ -1,9 +1,9 @@
 package com.kernel360.bbs.repository;
 
-import com.kernel360.bbs.entity.BBS;
+import com.kernel360.bbs.dto.BBSListDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface BBSRepositoryDSL {
-    Page<BBS> getBBSWithCondition(String bbsType, String keyword, Pageable pageable);
+    Page<BBSListDto> getBBSWithCondition(String bbsType, String keyword, Pageable pageable);
 }

--- a/module-api/src/main/java/com/kernel360/bbs/repository/BBSRepositoryDSL.java
+++ b/module-api/src/main/java/com/kernel360/bbs/repository/BBSRepositoryDSL.java
@@ -1,0 +1,4 @@
+package com.kernel360.bbs.repository;
+
+public interface BBSRepositoryDSL extends BBSRepository {
+}

--- a/module-api/src/main/java/com/kernel360/bbs/repository/BBSRepositoryDSL.java
+++ b/module-api/src/main/java/com/kernel360/bbs/repository/BBSRepositoryDSL.java
@@ -1,4 +1,9 @@
 package com.kernel360.bbs.repository;
 
-public interface BBSRepositoryDSL extends BBSRepository {
+import com.kernel360.bbs.entity.BBS;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface BBSRepositoryDSL {
+    Page<BBS> getBBSWithCondition(String bbsType, String keyword, Pageable pageable);
 }

--- a/module-api/src/main/java/com/kernel360/bbs/repository/BBSRepositoryDSLImpl.java
+++ b/module-api/src/main/java/com/kernel360/bbs/repository/BBSRepositoryDSLImpl.java
@@ -1,10 +1,8 @@
 package com.kernel360.bbs.repository;
 
-import com.kernel360.bbs.dto.BBSDto;
-import com.kernel360.bbs.entity.BBS;
+import com.kernel360.bbs.dto.BBSListDto;
 import com.kernel360.bbs.enumset.BBSType;
 import com.querydsl.core.types.Predicate;
-import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -12,12 +10,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.support.PageableExecutionUtils;
 
 import java.util.List;
+import java.util.Objects;
 
 import static com.kernel360.bbs.entity.QBBS.bBS;
 import static com.kernel360.member.entity.QMember.member;
+import static com.querydsl.core.types.Projections.fields;
 import static org.springframework.util.StringUtils.hasText;
 
 @RequiredArgsConstructor
@@ -26,14 +25,16 @@ public class BBSRepositoryDSLImpl implements BBSRepositoryDSL {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<BBS> getBBSWithCondition(String bbsType, String keyword, Pageable pageable) {
+    public Page<BBSListDto> getBBSWithCondition(String type, String keyword, Pageable pageable) {
 
         Predicate finalPredicate = bBS.isVisible.eq(true)
-                                                .and(bBS.type.eq(BBSType.valueOf(bbsType).name()))
-                                                .and(keywordContains(keyword));
+                                   .and(bBS.type.eq(BBSType.valueOf(type).name()));
 
-        List<BBS> bbs = getBBSWithMember().
-                                            where(finalPredicate)
+        List<BBSListDto> bbs = getBBSListWithMember().
+                                            where(
+                                                    finalPredicate,
+                                                    keywordContains(keyword)
+                                            )
                                             .orderBy(bBS.createdAt.desc())
                                             .offset(pageable.getOffset())
                                             .limit(pageable.getPageSize())
@@ -43,27 +44,37 @@ public class BBSRepositoryDSLImpl implements BBSRepositoryDSL {
                 .select(bBS.count())
                 .from(bBS)
                 .where(
-                        keywordContains(keyword),
-                        bBS.isVisible.eq(true)
+                        finalPredicate,
+                        keywordContains(keyword)
                 )
                 .fetchOne();
 
         return new PageImpl<>(bbs, pageable, totalCount);
-        //return PageableExecutionUtils.getPage(bbs, pageable, totalCount);
     }
 
-    private JPAQuery<BBS> getBBSWithMember() {
+    private JPAQuery<BBSListDto> getBBSListWithMember() {
         return queryFactory
-                .select(bBS)
+                .select(fields(BBSListDto.class,
+                        bBS.bbsNo,
+                        bBS.title,
+                        bBS.type,
+                        bBS.createdAt,
+                        bBS.createdBy,
+                        bBS.viewCount,
+                        bBS.member.memberNo,
+                        bBS.member.id
+                        )
+
+                )
                 .from(bBS)
                 .join(member).on(bBS.member.memberNo.eq(member.memberNo));
     }
 
-    private BooleanExpression keywordContains(String keyword) {
+    private BooleanExpression keywordContains(String keyword) {   //우선 참이 된다면 하위 조건 결과는 포함 안됨.
         return hasText(keyword) ?
                 bBS.title.contains(keyword)
                .or(bBS.contents.contains(keyword))
-               .or(bBS.member.id.eq(keyword))
+               .or(bBS.createdBy.eq(keyword))
                 : null;
     }
 

--- a/module-api/src/main/java/com/kernel360/bbs/repository/BBSRepositoryDSLImpl.java
+++ b/module-api/src/main/java/com/kernel360/bbs/repository/BBSRepositoryDSLImpl.java
@@ -1,0 +1,95 @@
+package com.kernel360.bbs.repository;
+
+import com.kernel360.bbs.dto.BBSDto;
+import com.kernel360.bbs.entity.BBS;
+import com.kernel360.file.entity.FileReferType;
+import com.kernel360.review.dto.ReviewSearchDto;
+import com.kernel360.review.dto.ReviewSearchResult;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+import java.util.List;
+
+import static com.kernel360.member.entity.QMember.member;
+import static com.kernel360.product.entity.QProduct.product;
+import static com.kernel360.review.entity.QReview.review;
+import static com.querydsl.core.types.ExpressionUtils.orderBy;
+import static com.querydsl.core.types.dsl.Expressions.stringTemplate;
+
+@RequiredArgsConstructor
+public class BBSRepositoryDSLImpl implements BBSRepositoryDSL {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<BBSDto> getBBSWithCondition(String sortType, String keyword, Pageable pageable) {
+
+        List<BBSDto> bbs = getBBSWithMember().
+                where(
+                        titleLike
+                ).
+                .orderBy(sort(sortType))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> totalCountQuery = queryFactory
+                .select(bbs.count())
+                .from(bbs)
+                .where(
+                        bbs.isVisible.eq(true)
+                );
+
+        return PageableExecutionUtils.getPage(bbs, pageable, totalCountQuery::fetchOne);
+    }
+
+    @Override
+    public Page<ReviewSearchResult> findAllByCondition(ReviewSearchDto condition, Pageable pageable) {
+        List<ReviewSearchResult> reviews =
+                getJoinedResults()
+                        .where(
+                                productNoEq(condition.productNo()), // 조건절 메서드 별도 생성
+                                memberNoEq(condition.memberNo())
+                        )
+                        .groupBy(review.reviewNo, member.memberNo, member.id, member.age, member.gender, product.productNo)
+                        .orderBy(sort(condition.sortBy()))
+                        .offset(pageable.getOffset())
+                        .limit(pageable.getPageSize())
+                        .fetch();
+
+        JPAQuery<Long> totalCountQuery = queryFactory
+                .select(review.count())
+                .from(review)
+                .where(
+                        review.isVisible.eq(true),
+                        productNoEq(condition.productNo()),
+                        memberNoEq(condition.memberNo())
+                );
+
+        return PageableExecutionUtils.getPage(reviews, pageable, totalCountQuery::fetchOne);
+    }
+
+    private JPAQuery<BBSDto> getBBSWithMember() {
+        return queryFactory
+                .select(Projections.fields(BBSDto.class,
+                        bbs.bbsNo,
+                        bbs.title,
+                        bbs.contents,
+                        bbs.createdAt,
+                        bbs.createdBy,
+                        bbs.modifiedAt,
+                        bbs.modifiedBy,
+                        member.memberNo,
+                        member.id,
+                        member.age,
+                        member.gender
+                ))
+                .from(bbs)
+                .join(member);
+    }
+}

--- a/module-api/src/main/java/com/kernel360/bbs/service/BBSService.java
+++ b/module-api/src/main/java/com/kernel360/bbs/service/BBSService.java
@@ -12,8 +12,8 @@ import org.springframework.stereotype.Service;
 public class BBSService {
     private final BBSRepository bbsRepository;
 
-    public Page<BBSDto> getBBSWithCondition(String sortType, String keyword, Pageable pageable) {
+    public Page<BBSDto> getBBSWithCondition(String bbsType, String keyword, Pageable pageable) {
 
-        return bbsRepository.getBBSWithCondition(sortType, keyword, pageable);
+        return bbsRepository.getBBSWithCondition(bbsType, keyword, pageable).map(BBSDto::from);
     }
 }

--- a/module-api/src/main/java/com/kernel360/bbs/service/BBSService.java
+++ b/module-api/src/main/java/com/kernel360/bbs/service/BBSService.java
@@ -1,19 +1,48 @@
 package com.kernel360.bbs.service;
 
 import com.kernel360.bbs.dto.BBSDto;
+import com.kernel360.bbs.dto.BBSListDto;
+import com.kernel360.bbs.entity.BBS;
 import com.kernel360.bbs.repository.BBSRepository;
+import com.kernel360.member.dto.MemberDto;
+import com.kernel360.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class BBSService {
     private final BBSRepository bbsRepository;
+    private final MemberService memberService;
 
-    public Page<BBSDto> getBBSWithCondition(String bbsType, String keyword, Pageable pageable) {
+    public Page<BBSListDto> getBBSWithCondition(String type, String keyword, Pageable pageable) {
 
-        return bbsRepository.getBBSWithCondition(bbsType, keyword, pageable).map(BBSDto::from);
+        return bbsRepository.getBBSWithCondition(type, keyword, pageable);
+    }
+
+    public BBSDto getBBSView(Long bbsNo) {
+
+        return BBSDto.from(bbsRepository.findOneByBbsNo(bbsNo));
+    }
+
+    public Page<BBSDto> getBBSReply(Long upperNo, Pageable pageable) {
+
+        return bbsRepository.findAllByUpperNo(upperNo, pageable).map(BBSDto::from);
+    }
+
+    @Transactional
+    public void saveBBS(BBSDto bbsDto, String id) {
+
+        MemberDto memberDto = memberService.findByMemberId(id);
+
+        bbsRepository.save(BBS.save(bbsDto.bbsNo(), bbsDto.upperNo(), bbsDto.type(), bbsDto.title(), bbsDto.contents(), true, 0L, memberDto.toEntity()));
+    }
+
+    @Transactional
+    public void deleteBBS(Long bbsNo) {
+        bbsRepository.deleteByBbsNo(bbsNo);
     }
 }

--- a/module-api/src/main/java/com/kernel360/bbs/service/BBSService.java
+++ b/module-api/src/main/java/com/kernel360/bbs/service/BBSService.java
@@ -1,0 +1,19 @@
+package com.kernel360.bbs.service;
+
+import com.kernel360.bbs.dto.BBSDto;
+import com.kernel360.bbs.repository.BBSRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BBSService {
+    private final BBSRepository bbsRepository;
+
+    public Page<BBSDto> getBBSWithCondition(String sortType, String keyword, Pageable pageable) {
+
+        return bbsRepository.getBBSWithCondition(sortType, keyword, pageable);
+    }
+}

--- a/module-api/src/main/java/com/kernel360/global/config/AuditConfig.java
+++ b/module-api/src/main/java/com/kernel360/global/config/AuditConfig.java
@@ -13,7 +13,7 @@ public class AuditConfig implements AuditorAware<String> {
     @Override
     public Optional<String> getCurrentAuditor() {
         HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
-        String createId = Optional.ofNullable(request.getParameter("Id")).orElse("admin");
+        String createId = Optional.ofNullable(request.getHeader("Id")).orElse("admin");
 
         return Optional.of(createId);
     }

--- a/module-api/src/main/java/com/kernel360/global/config/AuditConfig.java
+++ b/module-api/src/main/java/com/kernel360/global/config/AuditConfig.java
@@ -1,4 +1,4 @@
-package com.kernel360.member.config;
+package com.kernel360.global.config;
 
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.context.annotation.Configuration;
@@ -13,7 +13,7 @@ public class AuditConfig implements AuditorAware<String> {
     @Override
     public Optional<String> getCurrentAuditor() {
         HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
-        String createId = Optional.ofNullable(request.getParameter("id")).orElse("admin");
+        String createId = Optional.ofNullable(request.getParameter("Id")).orElse("admin");
 
         return Optional.of(createId);
     }

--- a/module-api/src/main/java/com/kernel360/member/controller/MemberController.java
+++ b/module-api/src/main/java/com/kernel360/member/controller/MemberController.java
@@ -92,7 +92,7 @@ public class MemberController {
     @PostMapping("/find-password")
     public ResponseEntity<ApiResponse<Object>> sendPasswordResetUriByEmail(@RequestBody MemberCredentialDto dto) {
         //--입력받은 아이디를 데이터베이스에 조회, 없으면 예외 발생--/
-        MemberDto memberDto = memberService.findByMemberId(dto.memberId());
+        MemberDto memberDto = memberService.findOneByIdForAccountTypeByPlatform(dto.memberId());
         //--유효성이 검증된 아이디에 대해서 만료시간이 있는 비밀번호 초기화 (호스트 + UUID) 링크 생성 --//
         String resetUri = findCredentialService.generatePasswordResetPageUri(memberDto);
         //-- 가입시 입력한 이메일로 비밀번호 초기화 이메일 발송 --//

--- a/module-api/src/main/java/com/kernel360/member/service/MemberService.java
+++ b/module-api/src/main/java/com/kernel360/member/service/MemberService.java
@@ -238,7 +238,7 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
-    public MemberDto findByMemberId(String memberId) {
+    public MemberDto findOneByIdForAccountTypeByPlatform(String memberId) {
         Member member = memberRepository.findOneByIdForAccountTypeByPlatform(memberId);
         if (member == null) {
             throw new BusinessException(MemberErrorCode.FAILED_FIND_MEMBER_INFO);
@@ -283,5 +283,10 @@ public class MemberService {
         Member member = memberRepository.findOneById(id);
 
         return member.getPassword().equals(ConvertSHA256.convertToSHA256(password));
+    }
+
+    public MemberDto findByMemberId(String id) {
+        Member member = memberRepository.findOneById(id);
+        return MemberDto.from(member);
     }
 }

--- a/module-api/src/main/resources/db/migration/V1.0.11__create_BBS.sql
+++ b/module-api/src/main/resources/db/migration/V1.0.11__create_BBS.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS bbs (
+    bbs_no      BIGSERIAL PRIMARY KEY,
+    upper_no    BIGINT,
+    member_no   BIGINT NOT NULL,
+    type        VARCHAR NOT NULL,
+    title       VARCHAR NOT NULL,
+    contents    VARCHAR NOT NULL,
+    is_visible  BOOL NOT NULL DEFAULT TRUE,
+    view_count  BIGINT NOT NULL,
+    created_at  DATE NOT NULL,
+    created_by  VARCHAR NOT NULL,
+    modified_at DATE,
+    modified_by VARCHAR,
+    FOREIGN KEY (member_no) REFERENCES Member (member_no)
+    );
+
+AlTER SEQUENCE bbs_bbs_no_seq increment by 50;

--- a/module-api/src/main/resources/db/migration/V1.0.15__create_BBS.sql
+++ b/module-api/src/main/resources/db/migration/V1.0.15__create_BBS.sql
@@ -7,9 +7,9 @@ CREATE TABLE IF NOT EXISTS bbs (
     contents    VARCHAR NOT NULL,
     is_visible  BOOL NOT NULL DEFAULT TRUE,
     view_count  BIGINT NOT NULL,
-    created_at  DATE NOT NULL,
+    created_at  TIMESTAMP NOT NULL,
     created_by  VARCHAR NOT NULL,
-    modified_at DATE,
+    modified_at TIMESTAMP,
     modified_by VARCHAR,
     FOREIGN KEY (member_no) REFERENCES Member (member_no)
     );

--- a/module-api/src/test/java/com/kernel360/member/controller/MemberControllerTest.java
+++ b/module-api/src/test/java/com/kernel360/member/controller/MemberControllerTest.java
@@ -151,7 +151,7 @@ class MemberControllerTest extends ControllerTest {
         MemberCredentialDto credentialDto = MemberCredentialDto.of(null, null, "kernel360", null);
         MemberDto memberDto = MemberDto.of("testMemberId", "testPassword001");
 
-        given(memberService.findByMemberId(credentialDto.memberId())).willReturn(memberDto);
+        given(memberService.findOneByIdForAccountTypeByPlatform(credentialDto.memberId())).willReturn(memberDto);
         given(findCredentialService.generatePasswordResetPageUri(memberDto)).willReturn("테스트 URI");
 
         ObjectMapper objectMapper = new ObjectMapper();

--- a/module-domain/src/main/java/com/kernel360/bbs/entity/BBS.java
+++ b/module-domain/src/main/java/com/kernel360/bbs/entity/BBS.java
@@ -27,7 +27,7 @@ public class BBS extends BaseEntity {
 
     private Boolean isVisible;
 
-    private Long viewConut;
+    private Long viewCount;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "member_no", nullable = false, updatable = false)
@@ -41,7 +41,7 @@ public class BBS extends BaseEntity {
         this.contents = contents;
         this.isVisible = isVisible;
         this.member = member;
-        this.viewConut = viewConut;
+        this.viewCount = viewConut;
     }
 
     public BBS of (Long bbsNo, Long upperNo, String type, String title, String contents, Boolean isVisible, Long viewConut, Member member){

--- a/module-domain/src/main/java/com/kernel360/bbs/entity/BBS.java
+++ b/module-domain/src/main/java/com/kernel360/bbs/entity/BBS.java
@@ -1,0 +1,50 @@
+package com.kernel360.bbs.entity;
+
+import com.kernel360.base.BaseEntity;
+import com.kernel360.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "bbs")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BBS extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "bbs_id_gen")
+    @SequenceGenerator(name = "bbs_id_gen", sequenceName = "bbs_no_seq")
+    private Long bbsNo;
+
+    private Long upperNo;
+
+    private String type;
+
+    private String title;
+
+    private String contents;
+
+    private Boolean isVisible;
+
+    private Long viewConut;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_no", nullable = false, updatable = false)
+    private Member member;
+
+    public BBS(Long bbsNo, Long upperNo, String type, String title, String contents, Boolean isVisible, Long viewConut, Member member) {
+        this.bbsNo = bbsNo;
+        this.upperNo = upperNo;
+        this.type = type;
+        this.title = title;
+        this.contents = contents;
+        this.isVisible = isVisible;
+        this.member = member;
+        this.viewConut = viewConut;
+    }
+
+    public BBS of (Long bbsNo, Long upperNo, String type, String title, String contents, Boolean isVisible, Long viewConut, Member member){
+        return new BBS (bbsNo, upperNo, type, title, contents, isVisible, viewConut, member);
+    }
+}

--- a/module-domain/src/main/java/com/kernel360/bbs/entity/BBS.java
+++ b/module-domain/src/main/java/com/kernel360/bbs/entity/BBS.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 public class BBS extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "bbs_id_gen")
-    @SequenceGenerator(name = "bbs_id_gen", sequenceName = "bbs_no_seq")
+    @SequenceGenerator(name = "bbs_id_gen", sequenceName = "bbs_bbs_no_seq")
     private Long bbsNo;
 
     private Long upperNo;
@@ -33,7 +33,7 @@ public class BBS extends BaseEntity {
     @JoinColumn(name = "member_no", nullable = false, updatable = false)
     private Member member;
 
-    public BBS(Long bbsNo, Long upperNo, String type, String title, String contents, Boolean isVisible, Long viewConut, Member member) {
+    private BBS(Long bbsNo, Long upperNo, String type, String title, String contents, Boolean isVisible, Long viewConut, Member member) {
         this.bbsNo = bbsNo;
         this.upperNo = upperNo;
         this.type = type;
@@ -44,7 +44,9 @@ public class BBS extends BaseEntity {
         this.viewCount = viewConut;
     }
 
-    public BBS of (Long bbsNo, Long upperNo, String type, String title, String contents, Boolean isVisible, Long viewConut, Member member){
-        return new BBS (bbsNo, upperNo, type, title, contents, isVisible, viewConut, member);
+    public static BBS save(Long bbsNo, Long upperNo, String type, String title, String contents, Boolean isVisible, Long viewCount, Member member){
+
+        return new BBS (bbsNo, upperNo, type, title, contents, isVisible, viewCount, member);
     }
+
 }

--- a/module-domain/src/main/java/com/kernel360/bbs/repository/BBSRepositoryJPA.java
+++ b/module-domain/src/main/java/com/kernel360/bbs/repository/BBSRepositoryJPA.java
@@ -2,7 +2,15 @@ package com.kernel360.bbs.repository;
 
 import com.kernel360.bbs.entity.BBS;
 import jakarta.persistence.Id;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BBSRepositoryJPA extends JpaRepository<BBS, Id> {
+    BBS findOneByBbsNo(Long bbsNo);
+
+    Page<BBS> findAllByUpperNo(Long upperNo, Pageable pageable);
+
+
+    void deleteByBbsNo(Long bbsNo);
 }

--- a/module-domain/src/main/java/com/kernel360/bbs/repository/BBSRepositoryJPA.java
+++ b/module-domain/src/main/java/com/kernel360/bbs/repository/BBSRepositoryJPA.java
@@ -1,0 +1,8 @@
+package com.kernel360.bbs.repository;
+
+import com.kernel360.bbs.entity.BBS;
+import jakarta.persistence.Id;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BBSRepositoryJPA extends JpaRepository<BBS, Id> {
+}


### PR DESCRIPTION
## 💡 Motivation and Context
`여기에 왜 이 PR이 필요했는지, PR을 통해 무엇이 바뀌는지에 대해서 설명해 주세요`
게시판 API 초안을 작성 하였습니다.
CRUD의 대한 API 통신 테스트 완료하였습니다. 편의상 성공 이미지는 하나만 올렸습니다.

![image](https://github.com/Kernel360/F1-WashFit-BE/assets/103917282/f4545fae-9e19-44e4-ba53-182e702c1c0f)

<br>

## 🔨 Modified
> 여기에 무엇이 크게 바뀌었는지 설명해 주세요
  
  -이제는 ID를 찾기위해 토큰 탐색을 하지 않고, 헤더에서 즉시 가져다 쓰면 됩니다.
   안타깝게도 memberNo를 알기 위해서는 findById를 여전히 써야하긴 합니다.
   -> 아래 more 항목의 리팩토링 관련하여 작업 진행시 프론트에서 memberNo도 같이 보내어
   별도 과정없이 저장해야 할 테이블에 즉시 insert 처리를 할 수 있을꺼라 판단됩니다.
   도메인 작업하시면서 코드 수정 할 일이 생긴다면 관련하여 리팩토링 진행 부탁드립니다.
![image](https://github.com/Kernel360/F1-WashFit-BE/assets/103917282/bd658475-fc5a-49a4-8eb8-30c0a514948a)

  - 게시글 타입은 아래와 같이 Enum 클래스로 관리되고 정의됩니다.
    QNA 질문과 답변 , FREE 자유게시판 , BOAST 자랑게시판 , RECOMMAND 추천게시판 , NOTICE , 공지사항 , REPLY 댓글 
![image](https://github.com/Kernel360/F1-WashFit-BE/assets/103917282/0f0dd941-435d-47c8-956f-485dc1eec72b)


  - 게시판 작성 후 댓글에 대해선 bbsNo에 대해 upperNo를 기반으로 테이블 트리 구조를 가져갑니다.  
     즉, 특정 글의 댓글 조회시엔 upperNo를 조회 조건으로 가져가면 됩니다.
  
  - 게시글 등록과 수정 처리는 saveBBS 메서드 하나만을 사용합니다. ~~의도치않은 클린코드~~
  
![image](https://github.com/Kernel360/F1-WashFit-BE/assets/103917282/685babbe-7d7c-485d-a34d-fc392767d55e)



<br>

## 🌟 More
- _여기에 PR 이후 추가로 해야 할 일에 대해서 설명해 주세요_

<br>
 - 프론트엔드 개발자와 API 연동시 검색에 대한 필터 조건 추가 필요 할 수 있습니다.
<br>
 - 첨부파일 로직이 추가 되어야 합니다.
<br>
 - 플랫폼 전체 조회 로직을 볼 때 조회, 등록시 연관관계가 있는 정보에 대해 필요 이상으로 많이 조회합니다. 
 <br>   이 부분에 대해 필요한 정보만 주고 받도록 리팩토링 필요합니다.
<br>
 - 테스트코드 작성해야 합니다.
 <br>
 - JPA delete 메서드를 사용해서 삭제 요청을 보내면 바로 flush가 되지 않는 이슈가 있습니다.

---


### 📋 커밋 전 체크리스트
- [ ] 추가/변경에 대한 단위 테스트를 완료하였습니다.
- [ ] 컨벤션에 맞게 작성하였습니다.

<br>

### 🤟🏻 PR로 완료된 이슈
closes #275, #284 
