### PR TITLE
fix :: 로그 출력시 Trie를 이용한 denined 목록 추가

### DIFF
--- a/module-api/build.gradle
+++ b/module-api/build.gradle
@@ -84,6 +84,10 @@ dependencies {
     annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
+    // https://mvnrepository.com/artifact/org.apache.commons/commons-collections4
+    implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
+
 }
 
 tasks.named('test') {

--- a/module-api/src/main/java/com/kernel360/global/filter/LogFilter.java
+++ b/module-api/src/main/java/com/kernel360/global/filter/LogFilter.java
@@ -4,6 +4,8 @@ import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.Trie;
+import org.apache.commons.collections4.trie.PatriciaTrie;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.ContentCachingRequestWrapper;
 import org.springframework.web.util.ContentCachingResponseWrapper;
@@ -18,6 +20,13 @@ public class LogFilter implements Filter {
     public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain) throws IOException, ServletException {
         ContentCachingRequestWrapper request = new ContentCachingRequestWrapper((HttpServletRequest) req);
         ContentCachingResponseWrapper response = new ContentCachingResponseWrapper((HttpServletResponse) res);
+
+        if(!deninedList().containsKey(request.getRequestURI())) {
+            printLog(chain, request, response);
+        }
+    }
+
+    private static void printLog(FilterChain chain, ContentCachingRequestWrapper request, ContentCachingResponseWrapper response) throws IOException, ServletException {
         log.info("##### INIT URI: {}", request.getRequestURI());
 
         chain.doFilter(request, response);
@@ -57,5 +66,12 @@ public class LogFilter implements Filter {
         log.info("##### RESPONSE ##### uri: {}, method: {}, header: {}, body: {}", uri, method, responseHeaderValues, responseBody);
 
         response.copyBodyToResponse();
+    }
+
+    private Trie<String, Integer> deninedList (){
+        Trie<String, Integer> trie = new PatriciaTrie<>();
+
+        trie.put("/actuator/prometheus",0);
+        return trie;
     }
 }

--- a/module-api/src/main/resources/application-dev.yml
+++ b/module-api/src/main/resources/application-dev.yml
@@ -59,7 +59,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: "*"
+        include: "prometheus, health"
   endpoint:
     health:
       show-details: never

--- a/module-api/src/main/resources/application-local.yml
+++ b/module-api/src/main/resources/application-local.yml
@@ -65,10 +65,10 @@ management:
   endpoints:
     web:
       exposure:
-        include: "*"
+        include: "prometheus, health"
   endpoint:
     health:
-      show-details: always
+      show-details: never
 
 constants:
   host-url: "http://localhost:3000"

--- a/module-api/src/main/resources/application-prod.yml
+++ b/module-api/src/main/resources/application-prod.yml
@@ -59,7 +59,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: "*"
+        include: "prometheus, health"
   endpoint:
     health:
       show-details: never


### PR DESCRIPTION
## 💡 Motivation and Context
`여기에 왜 이 PR이 필요했는지, PR을 통해 무엇이 바뀌는지에 대해서 설명해 주세요`
- 액추에이터 설정으로 로그 출력을 조정 할 수 없어 로그 필터를 조금 수정하였습니다.
<br>

## 🔨 Modified
> 여기에 무엇이 크게 바뀌었는지 설명해 주세요
  - Trie 자료구조를 이용하여 denined 리스트를 관리합니다.
  - 로컬에선 웹브라우저에서 액추에이터 확인 불가 및 모니터링은 가능한 상태임을 확인 하였고
     개발-운영환경에서도 동일한 보장을 하는지 확인이 필요합니다.

<br>

## 🌟 More
- _여기에 PR 이후 추가로 해야 할 일에 대해서 설명해 주세요_

<br>
Trie 자료구조의 장단점은 아래와 같고, 이를 이용해서 간단히 검색시 자동완성 기능을 구현 할 수 있습니다.<br>

![image](https://github.com/Kernel360/F1-WashFit-BE/assets/103917282/91e854ad-b65d-4052-9c4f-9fdde8e381b0)

---


### 📋 커밋 전 체크리스트
- [ ] 추가/변경에 대한 단위 테스트를 완료하였습니다.
- [x] 컨벤션에 맞게 작성하였습니다.

<br>

### 🤟🏻 PR로 완료된 이슈
closes #
